### PR TITLE
Changing into master branch during GitHub action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: run-tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   test:


### PR DESCRIPTION
As title, it should change into `master` branch and it should be same as active branch in repository.